### PR TITLE
Namespacing Fixes

### DIFF
--- a/advancedbenchmarking/include/budgetedpostingcollector.h
+++ b/advancedbenchmarking/include/budgetedpostingcollector.h
@@ -3,8 +3,8 @@
  * Apache License Version 2.0 http://www.apache.org/licenses/.
  *
  */
-#ifndef BUDGETEDPOSTINGCOLLECTOR_H_
-#define BUDGETEDPOSTINGCOLLECTOR_H_
+#ifndef SIMDCompressionAndIntersection_BUDGETEDPOSTINGCOLLECTOR_H_
+#define SIMDCompressionAndIntersection_BUDGETEDPOSTINGCOLLECTOR_H_
 
 
 #include "common.h"
@@ -230,4 +230,4 @@ private:
 
 
 
-#endif /* BUDGETEDPOSTINGCOLLECTOR_H_ */
+#endif /* SIMDCompressionAndIntersection_BUDGETEDPOSTINGCOLLECTOR_H_ */

--- a/advancedbenchmarking/include/budgetedpostingcollector.h
+++ b/advancedbenchmarking/include/budgetedpostingcollector.h
@@ -12,6 +12,7 @@
 #include "maropuparser.h"
 #include "intersection.h"
 
+using namespace SIMDCompressionLib;
 
 
 /*

--- a/advancedbenchmarking/include/maropuparser.h
+++ b/advancedbenchmarking/include/maropuparser.h
@@ -5,8 +5,8 @@
  * (c) Daniel Lemire, http://lemire.me/en/
  */
 
-#ifndef MAROPUPARSER_H_
-#define MAROPUPARSER_H_
+#ifndef SIMDCompressionAndIntersection_MAROPUPARSER_H_
+#define SIMDCompressionAndIntersection_MAROPUPARSER_H_
 
 #include <stdexcept>
 #include <sstream>
@@ -165,4 +165,4 @@ private:
 
 };
 
-#endif /* MAROPUPARSER_H_ */
+#endif /* SIMDCompressionAndIntersection_MAROPUPARSER_H_ */

--- a/advancedbenchmarking/include/statisticsrecorder.h
+++ b/advancedbenchmarking/include/statisticsrecorder.h
@@ -5,8 +5,8 @@
  */
 #
 
-#ifndef STATISTICSRECORDER_H_
-#define STATISTICSRECORDER_H_
+#ifndef SIMDCompressionAndIntersection_STATISTICSRECORDER_H_
+#define SIMDCompressionAndIntersection_STATISTICSRECORDER_H_
 
 #include "common.h"
 #include "timer.h"
@@ -89,4 +89,4 @@ private:
     vector<uint64_t> timesinmicros;
 };
 
-#endif /* STATISTICSRECORDER_H_ */
+#endif /* SIMDCompressionAndIntersection_STATISTICSRECORDER_H_ */

--- a/advancedbenchmarking/src/budgetedtest.cpp
+++ b/advancedbenchmarking/src/budgetedtest.cpp
@@ -20,6 +20,7 @@
 #include "hybm2.h"
 #include "statisticsrecorder.h"
 
+using namespace SIMDCompressionLib;
 
 uint32_t FakeCheckSum(const uint32_t *p, size_t qty) {
     return std::accumulate(p, p + qty, 0);

--- a/advancedbenchmarking/src/compflatstat.cpp
+++ b/advancedbenchmarking/src/compflatstat.cpp
@@ -12,6 +12,7 @@
 #include "timer.h"
 #include "maropuparser.h"
 
+using namespace SIMDCompressionLib;
 
 uint32_t FakeCheckSum(const uint32_t *p, size_t qty) {
     return std::accumulate(p, p + qty, 0);

--- a/advancedbenchmarking/src/compress.cpp
+++ b/advancedbenchmarking/src/compress.cpp
@@ -13,6 +13,7 @@
 #include "maropuparser.h"
 #include "codecfactory.h"
 
+using namespace SIMDCompressionLib;
 
 void printusage() {
     cout << " Try ./compress -s nameofscheme input.bin output.bin" << endl;

--- a/advancedbenchmarking/src/entropy.cpp
+++ b/advancedbenchmarking/src/entropy.cpp
@@ -14,6 +14,9 @@
 #include "delta.h"
 #include "budgetedpostingcollector.h"
 
+
+using namespace SIMDCompressionLib;
+
 void message(const char *prog) {
     cerr << " usage : " << prog << "  maropubinaryfile querylogfile"
          << endl;

--- a/advancedbenchmarking/src/readflat.cpp
+++ b/advancedbenchmarking/src/readflat.cpp
@@ -9,6 +9,8 @@
 #include "codecfactory.h"
 
 
+using namespace SIMDCompressionLib;
+
 void printusage(char *prog) {
     cout << "Usage: " << prog << " <uncompressed postings in the flat format>" << endl;
 

--- a/advancedbenchmarking/src/simplesynth.cpp
+++ b/advancedbenchmarking/src/simplesynth.cpp
@@ -12,6 +12,7 @@
 #include "timer.h"
 #include "synthetic.h"
 
+using namespace SIMDCompressionLib;
 
 void printusage() {
     cout << "This generate a file containing arrays. Each array is "

--- a/advancedbenchmarking/src/uncompress.cpp
+++ b/advancedbenchmarking/src/uncompress.cpp
@@ -13,6 +13,7 @@
 #include "maropuparser.h"
 #include "codecfactory.h"
 
+using namespace SIMDCompressionLib;
 
 void printusage() {
     cout << " Try ./uncompress input.bin output.bin" << endl;

--- a/example.cpp
+++ b/example.cpp
@@ -12,6 +12,8 @@
 #include "codecfactory.h"
 #include "intersection.h"
 
+using namespace SIMDCompressionLib;
+
 int main() {
     // We pick a CODEC
     IntegerCODEC &codec =  * CODECFactory::getFromName("s4-bp128-dm");

--- a/include/binarypacking.h
+++ b/include/binarypacking.h
@@ -12,6 +12,8 @@
 #include "bitpackinghelpers.h"
 #include "util.h"
 
+namespace SIMDCompressionLib {
+
 
 struct BasicBlockPacker {
     static void inline unpackblock(const uint32_t *in,  uint32_t *out,  const uint32_t bit, uint32_t &initoffset) {
@@ -184,5 +186,7 @@ public:
 };
 
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_BINARYPACKING_H_ */

--- a/include/binarypacking.h
+++ b/include/binarypacking.h
@@ -5,8 +5,8 @@
  * (c) Daniel Lemire, http://lemire.me/en/
  */
 
-#ifndef BINARYPACKING_H_
-#define BINARYPACKING_H_
+#ifndef SIMDCompressionAndIntersection_BINARYPACKING_H_
+#define SIMDCompressionAndIntersection_BINARYPACKING_H_
 
 #include "codecs.h"
 #include "bitpackinghelpers.h"
@@ -185,4 +185,4 @@ public:
 
 
 
-#endif /* BINARYPACKING_H_ */
+#endif /* SIMDCompressionAndIntersection_BINARYPACKING_H_ */

--- a/include/bitpacking.h
+++ b/include/bitpacking.h
@@ -4,8 +4,8 @@
  *
  * (c) Daniel Lemire, http://lemire.me/en/
  */
-#ifndef BITPACKING
-#define BITPACKING
+#ifndef SIMDCompressionAndIntersection_BITPACKING
+#define SIMDCompressionAndIntersection_BITPACKING
 #include <stdint.h>
 
 void __fastunpack0(const uint32_t   *__restrict__ in, uint32_t   *__restrict__  out);
@@ -111,4 +111,4 @@ void __fastpackwithoutmask30(const uint32_t   *__restrict__ in, uint32_t   *__re
 void __fastpackwithoutmask31(const uint32_t   *__restrict__ in, uint32_t   *__restrict__  out);
 void __fastpackwithoutmask32(const uint32_t   *__restrict__ in, uint32_t   *__restrict__  out);
 
-#endif // BITPACKING
+#endif // SIMDCompressionAndIntersection_BITPACKING

--- a/include/bitpacking.h
+++ b/include/bitpacking.h
@@ -8,6 +8,8 @@
 #define SIMDCompressionAndIntersection_BITPACKING
 #include <stdint.h>
 
+namespace SIMDCompressionLib {
+
 void __fastunpack0(const uint32_t   *__restrict__ in, uint32_t   *__restrict__  out);
 void __fastunpack1(const uint32_t   *__restrict__ in, uint32_t   *__restrict__  out);
 void __fastunpack2(const uint32_t   *__restrict__ in, uint32_t   *__restrict__  out);
@@ -110,5 +112,7 @@ void __fastpackwithoutmask29(const uint32_t   *__restrict__ in, uint32_t   *__re
 void __fastpackwithoutmask30(const uint32_t   *__restrict__ in, uint32_t   *__restrict__  out);
 void __fastpackwithoutmask31(const uint32_t   *__restrict__ in, uint32_t   *__restrict__  out);
 void __fastpackwithoutmask32(const uint32_t   *__restrict__ in, uint32_t   *__restrict__  out);
+
+} // namespace SIMDCompressionLib
 
 #endif // SIMDCompressionAndIntersection_BITPACKING

--- a/include/bitpackinghelpers.h
+++ b/include/bitpackinghelpers.h
@@ -5,8 +5,8 @@
  * (c) Leonid Boytsov, Nathan Kurz and Daniel Lemire
  */
 
-#ifndef BITPACKINGHELPERS_H_
-#define BITPACKINGHELPERS_H_
+#ifndef SIMDCompressionAndIntersection_BITPACKINGHELPERS_H_
+#define SIMDCompressionAndIntersection_BITPACKINGHELPERS_H_
 
 #include "bitpacking.h"
 #include "integratedbitpacking.h"
@@ -679,4 +679,4 @@ struct BitPackingHelpers {
 };
 
 
-#endif /* BITPACKINGHELPERS_H_ */
+#endif /* SIMDCompressionAndIntersection_BITPACKINGHELPERS_H_ */

--- a/include/bitpackinghelpers.h
+++ b/include/bitpackinghelpers.h
@@ -13,6 +13,8 @@
 #include "delta.h"
 #include "util.h"
 
+namespace SIMDCompressionLib {
+
 struct BitPackingHelpers {
     const static unsigned BlockSize = 32;
 
@@ -678,5 +680,7 @@ struct BitPackingHelpers {
     }
 };
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_BITPACKINGHELPERS_H_ */

--- a/include/boolarray.h
+++ b/include/boolarray.h
@@ -4,8 +4,8 @@
  *
  */
 
-#ifndef BOOLARRAY_H_
-#define BOOLARRAY_H_
+#ifndef SIMDCompressionAndIntersection_BOOLARRAY_H_
+#define SIMDCompressionAndIntersection_BOOLARRAY_H_
 
 #include "common.h"
 
@@ -197,4 +197,4 @@ public:
 };
 
 
-#endif /* BOOLARRAY_H_ */
+#endif /* SIMDCompressionAndIntersection_BOOLARRAY_H_ */

--- a/include/boolarray.h
+++ b/include/boolarray.h
@@ -9,6 +9,8 @@
 
 #include "common.h"
 
+namespace SIMDCompressionLib {
+
 using namespace std;
 
 
@@ -196,5 +198,7 @@ public:
 
 };
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_BOOLARRAY_H_ */

--- a/include/codecfactory.h
+++ b/include/codecfactory.h
@@ -5,8 +5,8 @@
  * (c) Daniel Lemire, http://lemire.me/en/
  */
 
-#ifndef CODECFACTORY_H_
-#define CODECFACTORY_H_
+#ifndef SIMDCompressionAndIntersection_CODECFACTORY_H_
+#define SIMDCompressionAndIntersection_CODECFACTORY_H_
 
 #include "common.h"
 #include "codecs.h"
@@ -164,4 +164,4 @@ map<string, shared_ptr<IntegerCODEC>> CODECFactory::scodecmap =
                                        initializefactory();
 
 shared_ptr<IntegerCODEC> CODECFactory::defaultptr = shared_ptr<IntegerCODEC>(nullptr);
-#endif /* CODECFACTORY_H_ */
+#endif /* SIMDCompressionAndIntersection_CODECFACTORY_H_ */

--- a/include/codecfactory.h
+++ b/include/codecfactory.h
@@ -25,6 +25,8 @@
 #include "variablebyte.h"
 #include "varintgb.h"
 
+namespace SIMDCompressionLib {
+
 using namespace std;
 
 typedef VariableByte<true>  leftovercodec;
@@ -164,4 +166,6 @@ map<string, shared_ptr<IntegerCODEC>> CODECFactory::scodecmap =
                                        initializefactory();
 
 shared_ptr<IntegerCODEC> CODECFactory::defaultptr = shared_ptr<IntegerCODEC>(nullptr);
+} // namespace SIMDCompressionLib
+
 #endif /* SIMDCompressionAndIntersection_CODECFACTORY_H_ */

--- a/include/codecs.h
+++ b/include/codecs.h
@@ -5,8 +5,8 @@
  * (c) Daniel Lemire, http://lemire.me/en/
  */
 
-#ifndef CODECS_H_
-#define CODECS_H_
+#ifndef SIMDCompressionAndIntersection_CODECS_H_
+#define SIMDCompressionAndIntersection_CODECS_H_
 
 
 #include "common.h"
@@ -133,4 +133,4 @@ public:
 };
 
 
-#endif /* CODECS_H_ */
+#endif /* SIMDCompressionAndIntersection_CODECS_H_ */

--- a/include/codecs.h
+++ b/include/codecs.h
@@ -13,6 +13,8 @@
 #include "util.h"
 #include "bitpackinghelpers.h"
 
+namespace SIMDCompressionLib {
+
 using namespace std;
 
 class NotEnoughStorage: public std::runtime_error {
@@ -132,5 +134,7 @@ public:
     }
 };
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_CODECS_H_ */

--- a/include/common.h
+++ b/include/common.h
@@ -4,8 +4,8 @@
  *
  * (c) Daniel Lemire, http://lemire.me/en/
  */
-#ifndef COMMON_H_
-#define COMMON_H_
+#ifndef SIMDCompressionAndIntersection_COMMON_H_
+#define SIMDCompressionAndIntersection_COMMON_H_
 
 
 #include <errno.h>
@@ -43,4 +43,4 @@
 #include <vector>
 
 
-#endif /* COMMON_H_ */
+#endif /* SIMDCompressionAndIntersection_COMMON_H_ */

--- a/include/common.h
+++ b/include/common.h
@@ -42,5 +42,9 @@
 #include <unordered_set>
 #include <vector>
 
+namespace SIMDCompressionLib {
+
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_COMMON_H_ */

--- a/include/compositecodec.h
+++ b/include/compositecodec.h
@@ -11,6 +11,8 @@
 #include "util.h"
 #include "codecs.h"
 
+namespace SIMDCompressionLib {
+
 /**
  * This is a useful class for CODEC that only compress
  * data having length a multiple of some unit length.
@@ -64,5 +66,7 @@ public:
         return convert.str();
     }
 };
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_COMPOSITECODEC_H_ */

--- a/include/compositecodec.h
+++ b/include/compositecodec.h
@@ -4,8 +4,8 @@
  *
  * (c) Daniel Lemire, http://lemire.me/en/
  */
-#ifndef COMPOSITECODEC_H_
-#define COMPOSITECODEC_H_
+#ifndef SIMDCompressionAndIntersection_COMPOSITECODEC_H_
+#define SIMDCompressionAndIntersection_COMPOSITECODEC_H_
 
 #include "common.h"
 #include "util.h"
@@ -65,4 +65,4 @@ public:
     }
 };
 
-#endif /* COMPOSITECODEC_H_ */
+#endif /* SIMDCompressionAndIntersection_COMPOSITECODEC_H_ */

--- a/include/delta.h
+++ b/include/delta.h
@@ -11,6 +11,8 @@
 
 #include "common.h"
 
+namespace SIMDCompressionLib {
+
 /**
  * To avoid crazy dependencies, this header should not
  * include any other header file.
@@ -79,5 +81,7 @@ void inverseDelta(const T initoffset, T *data) {
     }
 }
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_DELTA_H_ */

--- a/include/delta.h
+++ b/include/delta.h
@@ -5,8 +5,8 @@
  * (c) Leonid Boytsov, Nathan Kurz and Daniel Lemire
  */
 
-#ifndef DELTA_H_
-#define DELTA_H_
+#ifndef SIMDCompressionAndIntersection_DELTA_H_
+#define SIMDCompressionAndIntersection_DELTA_H_
 
 
 #include "common.h"
@@ -80,4 +80,4 @@ void inverseDelta(const T initoffset, T *data) {
 }
 
 
-#endif /* DELTA_H_ */
+#endif /* SIMDCompressionAndIntersection_DELTA_H_ */

--- a/include/deltatemplates.h
+++ b/include/deltatemplates.h
@@ -10,6 +10,8 @@
 
 #include "common.h"
 
+namespace SIMDCompressionLib {
+
 /**
  * To avoid crazy dependencies, this header should not
  * include any other header file.
@@ -160,5 +162,7 @@ struct SIMDDeltaProcessor {
 };
 
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_DELTATEMPLATES_H_ */

--- a/include/deltatemplates.h
+++ b/include/deltatemplates.h
@@ -5,8 +5,8 @@
  * (c) Leonid Boytsov, Nathan Kurz and Daniel Lemire
  */
 
-#ifndef DELTATEMPLATES_H_
-#define DELTATEMPLATES_H_
+#ifndef SIMDCompressionAndIntersection_DELTATEMPLATES_H_
+#define SIMDCompressionAndIntersection_DELTATEMPLATES_H_
 
 #include "common.h"
 
@@ -161,4 +161,4 @@ struct SIMDDeltaProcessor {
 
 
 
-#endif /* DELTATEMPLATES_H_ */
+#endif /* SIMDCompressionAndIntersection_DELTATEMPLATES_H_ */

--- a/include/fastpfor.h
+++ b/include/fastpfor.h
@@ -4,8 +4,8 @@
  * comparison purposes.
  */
 
-#ifndef FASTPFOR_H_
-#define FASTPFOR_H_
+#ifndef SIMDCompressionAndIntersection_FASTPFOR_H_
+#define SIMDCompressionAndIntersection_FASTPFOR_H_
 
 
 #include "common.h"
@@ -378,4 +378,4 @@ public:
 
 
 
-#endif /* FASTPFOR_H_ */
+#endif /* SIMDCompressionAndIntersection_FASTPFOR_H_ */

--- a/include/fastpfor.h
+++ b/include/fastpfor.h
@@ -14,6 +14,8 @@
 #include "util.h"
 #include "delta.h"
 
+namespace SIMDCompressionLib {
+
 
 
 class ScalarSortedBitPacker {
@@ -377,5 +379,7 @@ public:
 
 
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_FASTPFOR_H_ */

--- a/include/hybm2.h
+++ b/include/hybm2.h
@@ -7,8 +7,8 @@
  *      Implemented by Daniel Lemire
  */
 
-#ifndef HYBM2_H_
-#define HYBM2_H_
+#ifndef SIMDCompressionAndIntersection_HYBM2_H_
+#define SIMDCompressionAndIntersection_HYBM2_H_
 
 #include "common.h"
 #include "codecs.h"
@@ -636,4 +636,4 @@ private:
 
 
 };
-#endif /* HYBM2_H_ */
+#endif /* SIMDCompressionAndIntersection_HYBM2_H_ */

--- a/include/hybm2.h
+++ b/include/hybm2.h
@@ -17,6 +17,8 @@
 #include "intersection.h"
 #include "skipping.h"
 
+namespace SIMDCompressionLib {
+
 
 class HybM2 {
 public:
@@ -636,4 +638,6 @@ private:
 
 
 };
+} // namespace SIMDCompressionLib
+
 #endif /* SIMDCompressionAndIntersection_HYBM2_H_ */

--- a/include/integratedbitpacking.h
+++ b/include/integratedbitpacking.h
@@ -4,8 +4,8 @@
  *
  * (c) Daniel Lemire, http://lemire.me/en/
  */
-#ifndef INTEGRATEDBITPACKING
-#define INTEGRATEDBITPACKING
+#ifndef SIMDCompressionAndIntersection_INTEGRATEDBITPACKING
+#define SIMDCompressionAndIntersection_INTEGRATEDBITPACKING
 #include <stdint.h>
 
 
@@ -134,4 +134,4 @@ void __integratedfastpack31(const uint32_t initoffset, const uint32_t   *__restr
 void __integratedfastpack32(const uint32_t initoffset, const uint32_t   *__restrict__ in,
                             uint32_t   *__restrict__  out);
 
-#endif // INTEGRATEDBITPACKING
+#endif // SIMDCompressionAndIntersection_INTEGRATEDBITPACKING

--- a/include/integratedbitpacking.h
+++ b/include/integratedbitpacking.h
@@ -8,6 +8,8 @@
 #define SIMDCompressionAndIntersection_INTEGRATEDBITPACKING
 #include <stdint.h>
 
+namespace SIMDCompressionLib {
+
 
 void __integratedfastunpack0(const uint32_t initoffset, const uint32_t   *__restrict__ in,
                              uint32_t   *__restrict__  out);
@@ -133,5 +135,7 @@ void __integratedfastpack31(const uint32_t initoffset, const uint32_t   *__restr
                             uint32_t   *__restrict__  out);
 void __integratedfastpack32(const uint32_t initoffset, const uint32_t   *__restrict__ in,
                             uint32_t   *__restrict__  out);
+
+} // namespace SIMDCompressionLib
 
 #endif // SIMDCompressionAndIntersection_INTEGRATEDBITPACKING

--- a/include/intersection.h
+++ b/include/intersection.h
@@ -1,7 +1,7 @@
 
 
-#ifndef INTERSECTION_H_
-#define INTERSECTION_H_
+#ifndef SIMDCompressionAndIntersection_INTERSECTION_H_
+#define SIMDCompressionAndIntersection_INTERSECTION_H_
 
 #include <common.h>
 
@@ -91,4 +91,4 @@ public:
 
 
 
-#endif /* INTERSECTION_H_ */
+#endif /* SIMDCompressionAndIntersection_INTERSECTION_H_ */

--- a/include/intersection.h
+++ b/include/intersection.h
@@ -5,6 +5,8 @@
 
 #include <common.h>
 
+namespace SIMDCompressionLib {
+
 using namespace std;
 /*
  * Given two arrays, this writes the intersection to out. Returns the
@@ -90,5 +92,7 @@ public:
 };
 
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_INTERSECTION_H_ */

--- a/include/mersenne.h
+++ b/include/mersenne.h
@@ -9,6 +9,8 @@
 #include "common.h"
 #include "util.h"
 
+namespace SIMDCompressionLib {
+
 /**
  *  Mersenne twister - random number generator.
  *  Generate uniform distribution of 32 bit integers with the MT19937 algorithm.
@@ -94,5 +96,7 @@ unsigned int ZRandom::getValue() {
     y ^= y >> 18;
     return y;
 }
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_MERSENNE_H_ */

--- a/include/mersenne.h
+++ b/include/mersenne.h
@@ -3,8 +3,8 @@
  * Apache License Version 2.0 http://www.apache.org/licenses/.
  */
 
-#ifndef MERSENNE_H_
-#define MERSENNE_H_
+#ifndef SIMDCompressionAndIntersection_MERSENNE_H_
+#define SIMDCompressionAndIntersection_MERSENNE_H_
 
 #include "common.h"
 #include "util.h"
@@ -95,4 +95,4 @@ unsigned int ZRandom::getValue() {
     return y;
 }
 
-#endif /* MERSENNE_H_ */
+#endif /* SIMDCompressionAndIntersection_MERSENNE_H_ */

--- a/include/simdbinarypacking.h
+++ b/include/simdbinarypacking.h
@@ -5,8 +5,8 @@
  * (c) Daniel Lemire, http://lemire.me/en/
  */
 
-#ifndef SIMDBINARYPACKING_H_
-#define SIMDBINARYPACKING_H_
+#ifndef SIMDCompressionAndIntersection_SIMDBINARYPACKING_H_
+#define SIMDCompressionAndIntersection_SIMDBINARYPACKING_H_
 
 #include "codecs.h"
 #include "simdbitpackinghelpers.h"
@@ -236,4 +236,4 @@ public:
 
 };
 
-#endif /* SIMDBINARYPACKING_H_ */
+#endif /* SIMDCompressionAndIntersection_SIMDBINARYPACKING_H_ */

--- a/include/simdbinarypacking.h
+++ b/include/simdbinarypacking.h
@@ -12,6 +12,8 @@
 #include "simdbitpackinghelpers.h"
 #include "util.h"
 
+namespace SIMDCompressionLib {
+
 
 template <class DeltaHelper, bool ArrayDispatch>
 struct SIMDBlockPacker {
@@ -235,5 +237,7 @@ public:
     }
 
 };
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_SIMDBINARYPACKING_H_ */

--- a/include/simdbitpacking.h
+++ b/include/simdbitpacking.h
@@ -9,6 +9,8 @@
 
 #include "common.h"
 
+namespace SIMDCompressionLib {
+
 
 void __SIMD_fastunpack1(const  __m128i *, uint32_t *);
 void __SIMD_fastunpack2(const  __m128i *, uint32_t *);
@@ -113,5 +115,7 @@ void __SIMD_fastpack32(const uint32_t *, __m128i *);
 
 
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_SIMDBITPACKING_H_ */

--- a/include/simdbitpacking.h
+++ b/include/simdbitpacking.h
@@ -4,8 +4,8 @@
  *
  * (c) Daniel Lemire
  */
-#ifndef SIMDBITPACKING_H_
-#define SIMDBITPACKING_H_
+#ifndef SIMDCompressionAndIntersection_SIMDBITPACKING_H_
+#define SIMDCompressionAndIntersection_SIMDBITPACKING_H_
 
 #include "common.h"
 
@@ -114,4 +114,4 @@ void __SIMD_fastpack32(const uint32_t *, __m128i *);
 
 
 
-#endif /* SIMDBITPACKING_H_ */
+#endif /* SIMDCompressionAndIntersection_SIMDBITPACKING_H_ */

--- a/include/simdbitpackinghelpers.h
+++ b/include/simdbitpackinghelpers.h
@@ -15,6 +15,8 @@
 #include "delta.h"
 #include "util.h"
 
+namespace SIMDCompressionLib {
+
 const size_t SIMDBlockSize = 128;
 
 
@@ -647,5 +649,7 @@ struct SIMDBitPackingHelpers {
         }
     }
 };
+
+} // namespace SIMDCompressionLib
 
 #endif

--- a/include/simdbitpackinghelpers.h
+++ b/include/simdbitpackinghelpers.h
@@ -5,8 +5,8 @@
  * (c) Leonid Boytsov, Nathan Kurz and Daniel Lemire
  */
 
-#ifndef SIMD_BITPACKING_HELPERS_H_
-#define SIMD_BITPACKING_HELPERS_H_
+#ifndef SIMDCompressionAndIntersection_SIMD_BITPACKING_HELPERS_H_
+#define SIMDCompressionAndIntersection_SIMD_BITPACKING_HELPERS_H_
 
 #include "common.h"
 #include "simdbitpacking.h"

--- a/include/simdfastpfor.h
+++ b/include/simdfastpfor.h
@@ -4,8 +4,8 @@
  *
  * (c) Daniel Lemire, http://lemire.me/en/
  */
-#ifndef SIMDFASTPFOR_H_
-#define SIMDFASTPFOR_H_
+#ifndef SIMDCompressionAndIntersection_SIMDFASTPFOR_H_
+#define SIMDCompressionAndIntersection_SIMDFASTPFOR_H_
 
 #include "common.h"
 #include "codecs.h"
@@ -262,4 +262,4 @@ public:
 
 
 
-#endif /* SIMDFASTPFOR_H_ */
+#endif /* SIMDCompressionAndIntersection_SIMDFASTPFOR_H_ */

--- a/include/simdfastpfor.h
+++ b/include/simdfastpfor.h
@@ -14,6 +14,8 @@
 #include "util.h"
 #include "delta.h"
 
+namespace SIMDCompressionLib {
+
 
 
 /**
@@ -261,5 +263,7 @@ public:
 
 
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_SIMDFASTPFOR_H_ */

--- a/include/simdintegratedbitpacking.h
+++ b/include/simdintegratedbitpacking.h
@@ -5,8 +5,8 @@
  * (c) Leonid Boytsov, Nathan Kurz and Daniel Lemire
  */
 
-#ifndef SIMD_INTEGRATED_BITPACKING_H
-#define SIMD_INTEGRATED_BITPACKING_H
+#ifndef SIMDCompressionAndIntersection_SIMD_INTEGRATED_BITPACKING_H
+#define SIMDCompressionAndIntersection_SIMD_INTEGRATED_BITPACKING_H
 
 
 /**

--- a/include/simdintegratedbitpacking.h
+++ b/include/simdintegratedbitpacking.h
@@ -15,6 +15,8 @@
  */
 #include "deltatemplates.h"
 
+namespace SIMDCompressionLib {
+
 
 
 template <class DeltaHelper>
@@ -694,5 +696,7 @@ void SIMDipack(__m128i initOffset, const uint32_t    *in, __m128i     *out, cons
     }
     throw std::logic_error("number of bits is unsupported");
 }
+
+} // namespace SIMDCompressionLib
 
 #endif

--- a/include/simdvariablebyte.h
+++ b/include/simdvariablebyte.h
@@ -8,8 +8,8 @@
  * improved by Nathan Kurz.
  */
 
-#ifndef SIMDVARIABLEBYTE_H_
-#define SIMDVARIABLEBYTE_H_
+#ifndef SIMDCompressionAndIntersection_SIMDVARIABLEBYTE_H_
+#define SIMDCompressionAndIntersection_SIMDVARIABLEBYTE_H_
 
 #include "common.h"
 #include "codecs.h"
@@ -244,4 +244,4 @@ private:
 
 };
 
-#endif /* SIMDVARIABLEBYTE_H_ */
+#endif /* SIMDCompressionAndIntersection_SIMDVARIABLEBYTE_H_ */

--- a/include/simdvariablebyte.h
+++ b/include/simdvariablebyte.h
@@ -15,6 +15,8 @@
 #include "codecs.h"
 #include "util.h"
 
+namespace SIMDCompressionLib {
+
 extern "C" {
 void simdvbyteinit(void);
 size_t masked_vbyte_read_loop(const uint8_t* in, uint32_t* out, uint64_t length);
@@ -243,5 +245,7 @@ private:
     }
 
 };
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_SIMDVARIABLEBYTE_H_ */

--- a/include/skipping.h
+++ b/include/skipping.h
@@ -21,6 +21,8 @@
 
 #include "common.h"
 
+namespace SIMDCompressionLib {
+
 class Skipping {
 public:
 
@@ -270,5 +272,7 @@ void Skipping::load(const  uint32_t *data, uint32_t len) {
     mainbuffer.resize(static_cast<uint32_t>(bout - boutinit));
     mainbuffer.shrink_to_fit();
 }
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_SKIPPING_H_ */

--- a/include/skipping.h
+++ b/include/skipping.h
@@ -16,8 +16,8 @@
  *      Author: Daniel Lemire
  */
 
-#ifndef SKIPPING_H_
-#define SKIPPING_H_
+#ifndef SIMDCompressionAndIntersection_SKIPPING_H_
+#define SIMDCompressionAndIntersection_SKIPPING_H_
 
 #include "common.h"
 
@@ -271,4 +271,4 @@ void Skipping::load(const  uint32_t *data, uint32_t len) {
     mainbuffer.shrink_to_fit();
 }
 
-#endif /* SKIPPING_H_ */
+#endif /* SIMDCompressionAndIntersection_SKIPPING_H_ */

--- a/include/sortedbitpacking.h
+++ b/include/sortedbitpacking.h
@@ -13,6 +13,8 @@
 #include "simdbitpacking.h"
 #include "bitpackinghelpers.h"
 
+namespace SIMDCompressionLib {
+
 
 template <class T>
 __attribute__((const))
@@ -214,5 +216,7 @@ private:
 
 };
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_SORTEDBITPACKING_H_ */

--- a/include/sortedbitpacking.h
+++ b/include/sortedbitpacking.h
@@ -5,8 +5,8 @@
  * (c) Daniel Lemire, http://lemire.me/en/
  */
 
-#ifndef SORTEDBITPACKING_H_
-#define SORTEDBITPACKING_H_
+#ifndef SIMDCompressionAndIntersection_SORTEDBITPACKING_H_
+#define SIMDCompressionAndIntersection_SORTEDBITPACKING_H_
 
 
 #include "common.h"
@@ -215,4 +215,4 @@ private:
 };
 
 
-#endif /* SORTEDBITPACKING_H_ */
+#endif /* SIMDCompressionAndIntersection_SORTEDBITPACKING_H_ */

--- a/include/synthetic.h
+++ b/include/synthetic.h
@@ -15,6 +15,8 @@
 #include "intersection.h"
 #include "boolarray.h"
 
+namespace SIMDCompressionLib {
+
 using namespace std;
 
 
@@ -374,5 +376,7 @@ float intersectionratio) {
     return pair<vector<uint32_t>, vector<uint32_t>>(smallest, largest);
 }
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_SYNTHETIC_H_ */

--- a/include/synthetic.h
+++ b/include/synthetic.h
@@ -5,8 +5,8 @@
  * (c) Daniel Lemire
  */
 
-#ifndef SYNTHETIC_H_
-#define SYNTHETIC_H_
+#ifndef SIMDCompressionAndIntersection_SYNTHETIC_H_
+#define SIMDCompressionAndIntersection_SYNTHETIC_H_
 
 
 #include "common.h"
@@ -375,4 +375,4 @@ float intersectionratio) {
 }
 
 
-#endif /* SYNTHETIC_H_ */
+#endif /* SIMDCompressionAndIntersection_SYNTHETIC_H_ */

--- a/include/timer.h
+++ b/include/timer.h
@@ -4,8 +4,8 @@
  *
  */
 
-#ifndef TIMER_H_
-#define TIMER_H_
+#ifndef SIMDCompressionAndIntersection_TIMER_H_
+#define SIMDCompressionAndIntersection_TIMER_H_
 
 
 #include <sys/stat.h>
@@ -86,4 +86,4 @@ public:
 };
 #endif
 
-#endif /* TIMER_H_ */
+#endif /* SIMDCompressionAndIntersection_TIMER_H_ */

--- a/include/timer.h
+++ b/include/timer.h
@@ -12,6 +12,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
+namespace SIMDCompressionLib {
 
 class WallClockTimer {
 public:
@@ -85,5 +86,7 @@ public:
     }
 };
 #endif
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_TIMER_H_ */

--- a/include/usimdbitpacking.h
+++ b/include/usimdbitpacking.h
@@ -4,8 +4,8 @@
  *
  * (c) Daniel Lemire
  */
-#ifndef USIMDBITPACKING_H_
-#define USIMDBITPACKING_H_
+#ifndef SIMDCompressionAndIntersection_USIMDBITPACKING_H_
+#define SIMDCompressionAndIntersection_USIMDBITPACKING_H_
 
 #include "common.h"
 

--- a/include/usimdbitpacking.h
+++ b/include/usimdbitpacking.h
@@ -9,6 +9,8 @@
 
 #include "common.h"
 
+namespace SIMDCompressionLib {
+
 
 void __uSIMD_fastunpack1(const  __m128i *, uint32_t *);
 void __uSIMD_fastunpack2(const  __m128i *, uint32_t *);
@@ -114,5 +116,7 @@ void __uSIMD_fastpack32(const uint32_t *, __m128i *);
 
 
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDBITPACKING_H_ */

--- a/include/util.h
+++ b/include/util.h
@@ -10,6 +10,8 @@
 
 #include "common.h"
 
+namespace SIMDCompressionLib {
+
 inline uint32_t random(int b) {
     if (b == 32) return rand();
     return rand() % (1U << b);
@@ -140,4 +142,6 @@ bool is_strictlysorted(iterator first, iterator last)  {
     }
     return true;
 }
+} // namespace SIMDCompressionLib
+
 #endif /* SIMDCompressionAndIntersection_UTIL_H_ */

--- a/include/util.h
+++ b/include/util.h
@@ -5,8 +5,8 @@
  * (c) Daniel Lemire
  */
 
-#ifndef UTIL_H_
-#define UTIL_H_
+#ifndef SIMDCompressionAndIntersection_UTIL_H_
+#define SIMDCompressionAndIntersection_UTIL_H_
 
 #include "common.h"
 
@@ -140,4 +140,4 @@ bool is_strictlysorted(iterator first, iterator last)  {
     }
     return true;
 }
-#endif /* UTIL_H_ */
+#endif /* SIMDCompressionAndIntersection_UTIL_H_ */

--- a/include/variablebyte.h
+++ b/include/variablebyte.h
@@ -5,8 +5,8 @@
  * (c) Daniel Lemire, http://lemire.me/en/
  */
 
-#ifndef VARIABLEBYTE_H_
-#define VARIABLEBYTE_H_
+#ifndef SIMDCompressionAndIntersection_VARIABLEBYTE_H_
+#define SIMDCompressionAndIntersection_VARIABLEBYTE_H_
 #include "common.h"
 #include "codecs.h"
 #include "util.h"
@@ -403,4 +403,4 @@ private:
 };
 
 
-#endif /* VARIABLEBYTE_H_ */
+#endif /* SIMDCompressionAndIntersection_VARIABLEBYTE_H_ */

--- a/include/variablebyte.h
+++ b/include/variablebyte.h
@@ -11,6 +11,8 @@
 #include "codecs.h"
 #include "util.h"
 
+namespace SIMDCompressionLib {
+
 /***
  * VariableByte and VByte are basically identical, except that
  * one uses 0..0..0..1 to indicate 4 whereas the other one uses 1..1..1..0.
@@ -402,5 +404,7 @@ private:
 
 };
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_VARIABLEBYTE_H_ */

--- a/include/varintgb.h
+++ b/include/varintgb.h
@@ -5,8 +5,8 @@
  *      Author: lemire
  */
 
-#ifndef VARINTGB_H_
-#define VARINTGB_H_
+#ifndef SIMDCompressionAndIntersection_VARINTGB_H_
+#define SIMDCompressionAndIntersection_VARINTGB_H_
 
 #include "common.h"
 #include "codecs.h"
@@ -212,4 +212,4 @@ public:
 
 
 
-#endif /* VARINTGB_H_ */
+#endif /* SIMDCompressionAndIntersection_VARINTGB_H_ */

--- a/include/varintgb.h
+++ b/include/varintgb.h
@@ -12,6 +12,8 @@
 #include "codecs.h"
 #include "variablebyte.h"
 
+namespace SIMDCompressionLib {
+
 using namespace std;
 
 
@@ -211,5 +213,7 @@ public:
 
 
 
+
+} // namespace SIMDCompressionLib
 
 #endif /* SIMDCompressionAndIntersection_VARINTGB_H_ */

--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ endif #intel
 
 HEADERS= $(shell ls include/*h)
 
-all: unit  testcodecs  testintegration  advancedbenchmarking benchintersection
+all: unit  testcodecs  testintegration  advancedbenchmarking benchintersection libSIMDCompressionAndIntersection.a
 	echo "please run unit tests by running the unit executable"
 
 advancedbenchmarking: simplesynth compress uncompress budgetedtest entropy compflatstat
@@ -86,6 +86,9 @@ example:  $(HEADERS) example.cpp  $(OBJECTS)
 
 testintegration:  bitpacking.o simdbitpacking.o usimdbitpacking.o integratedbitpacking.o     simdintegratedbitpacking.o src/testintegration.cpp  $(HEADERS) 
 	$(CXX) $(CXXFLAGS) -Iinclude -o testintegration src/testintegration.cpp   bitpacking.o integratedbitpacking.o  simdbitpacking.o usimdbitpacking.o     simdintegratedbitpacking.o 
+
+libSIMDCompressionAndIntersection.a: $(OBJECTS)
+	ar rvs $@ $^
 
 
 

--- a/src/benchintersection.cpp
+++ b/src/benchintersection.cpp
@@ -14,6 +14,8 @@
 #include <likwid.h>
 #endif
 
+using namespace SIMDCompressionLib;
+
 /**
  * Goal: have the largest array count about 4M terms (this
  * matches our experiments), and vary the size of the

--- a/src/bitpacking.cpp
+++ b/src/bitpacking.cpp
@@ -7,7 +7,7 @@
 
 #include "bitpacking.h"
 
-
+namespace SIMDCompressionLib {
 
 
 void __fastunpack0(const uint32_t   *__restrict__ , uint32_t   *__restrict__  out) {
@@ -9229,3 +9229,4 @@ void fastpackwithoutmask(const uint32_t   *__restrict__ in, uint32_t   *__restri
     }
 }
 
+} // namespace SIMDCompressionLib

--- a/src/integratedbitpacking.cpp
+++ b/src/integratedbitpacking.cpp
@@ -8,6 +8,8 @@
 #include "integratedbitpacking.h"
 
 
+namespace SIMDCompressionLib {
+
 void __integratedfastunpack0(const uint32_t initoffset, const uint32_t   *__restrict__ ,
                              uint32_t   *__restrict__  out) {
     for (uint32_t i = 0; i < 32; ++i)
@@ -6784,4 +6786,4 @@ void __integratedfastpack16(const uint32_t initoffset, const uint32_t   *__restr
     ++out;
 }
 
-
+} // namespace SIMDCompressionLib

--- a/src/intersection.cpp
+++ b/src/intersection.cpp
@@ -6,6 +6,7 @@
 
 #include "intersection.h"
 
+namespace SIMDCompressionLib {
 
 /**
  * This is often called galloping or exponential search.
@@ -753,4 +754,4 @@ inline std::map<std::string, intersectionfunction> initializeintersectionfactory
 std::map<std::string, intersectionfunction> IntersectionFactory::intersection_schemes = initializeintersectionfactory();
 
 
-
+} // namespace SIMDCompressionLib

--- a/src/simdbitpacking.cpp
+++ b/src/simdbitpacking.cpp
@@ -6,6 +6,7 @@
  */
 #include "simdbitpacking.h"
 
+namespace SIMDCompressionLib {
 using namespace std;
 
 void __SIMD_fastpackwithoutmask0(const uint32_t   *__restrict__ , __m128i   *__restrict__) {}
@@ -13789,4 +13790,4 @@ void __SIMD_fastunpack32(const  __m128i  *__restrict__ in, uint32_t   *__restric
     }
 }
 
-
+} // namespace SIMDCompressionLib

--- a/src/simdintegratedbitpacking.cpp
+++ b/src/simdintegratedbitpacking.cpp
@@ -6,6 +6,7 @@
 */
 #include "simdintegratedbitpacking.h"
 
+namespace SIMDCompressionLib {
 
 
 template <class DeltaHelper>
@@ -25285,3 +25286,4 @@ template __m128i  iunpack32<Max4DeltaSIMD>(__m128i, const __m128i *, uint32_t *)
 template void ipack32<Max4DeltaSIMD>(__m128i, const uint32_t *, __m128i *);
 template void ipackwithoutmask32<Max4DeltaSIMD>(__m128i, const uint32_t *, __m128i *);
 
+} // namespace SIMDCompressionLib

--- a/src/testcodecs.cpp
+++ b/src/testcodecs.cpp
@@ -9,6 +9,8 @@
 #include "compositecodec.h"
 #include "codecfactory.h"
 
+using namespace SIMDCompressionLib;
+
 struct dataarray {
     dataarray() :
         name(), data() {

--- a/src/testintegration.cpp
+++ b/src/testintegration.cpp
@@ -13,7 +13,7 @@
 #include "synthetic.h"
 
 using namespace std;
-
+using namespace SIMDCompressionLib;
 
 
 vector<uint32_t> maskedcopy(const vector<uint32_t> &in, const uint32_t bit) {

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -19,7 +19,7 @@
 #include "codecfactory.h"
 
 using namespace std;
-
+using namespace SIMDCompressionLib;
 
 struct dataarray {
     dataarray() : name(), data() {}

--- a/src/usimdbitpacking.cpp
+++ b/src/usimdbitpacking.cpp
@@ -6,6 +6,7 @@
  */
 #include "simdbitpacking.h"
 
+namespace SIMDCompressionLib {
 using namespace std;
 
 /**
@@ -13785,3 +13786,5 @@ void __uSIMD_fastunpack32(const  __m128i  *__restrict__ in, uint32_t   *__restri
         _mm_storeu_si128(out++, _mm_loadu_si128(in++));
     }
 }
+
+} // namespace SIMDCompressionLib


### PR DESCRIPTION
I've renamed all `#ifndef`s, wrapped sources in a namespace, and updated the tests and example to match.
I also added a target in the makefile for building `libSIMDCompressionAndIntersection.a` for linking.
I've tested the build on my machine and everything seems to be in order.