### PR TITLE
Fix Visual C++ compiler warnings

### DIFF
--- a/include/boolarray.h
+++ b/include/boolarray.h
@@ -142,7 +142,7 @@ public:
      * prepare a new word and then append it.
      */
     ALWAYS_INLINE
-    inline void set(const size_t pos) {
+    void set(const size_t pos) {
         buffer[pos / 64] |= (static_cast<uint64_t>(1) << (pos
                              % 64));
     }
@@ -154,7 +154,7 @@ public:
      * prepare a new word and then append it.
      */
     ALWAYS_INLINE
-    inline void unset(const size_t pos) {
+    void unset(const size_t pos) {
         buffer[pos / 64] |= ~(static_cast<uint64_t>(1) << (pos
                               % 64));
     }
@@ -163,7 +163,7 @@ public:
      * true of false? (set or unset)
      */
     ALWAYS_INLINE
-    inline bool get(const size_t pos) const {
+    bool get(const size_t pos) const {
         return (buffer[pos / 64] & (static_cast<uint64_t>(1) << (pos
                                     % 64))) != 0;
     }

--- a/include/deltatemplates.h
+++ b/include/deltatemplates.h
@@ -27,14 +27,14 @@ namespace SIMDCompressionLib {
 struct RegularDeltaSIMD {
     // Folklore code, unknown origin of this idea
     ALWAYS_INLINE
-    static inline __m128i PrefixSum(__m128i curr, __m128i prev) {
+    static __m128i PrefixSum(__m128i curr, __m128i prev) {
         const __m128i _tmp1 = _mm_add_epi32(_mm_slli_si128(curr, 8), curr);
         const __m128i _tmp2 = _mm_add_epi32(_mm_slli_si128(_tmp1, 4), _tmp1);
         return _mm_add_epi32(_tmp2, _mm_shuffle_epi32(prev, 0xff));
     }
 
     ALWAYS_INLINE
-    static inline __m128i Delta(__m128i curr, __m128i prev) {
+    static __m128i Delta(__m128i curr, __m128i prev) {
         return _mm_sub_epi32(curr, _mm_or_si128(_mm_slli_si128(curr, 4), _mm_srli_si128(prev, 12)));
     }
 
@@ -45,11 +45,11 @@ struct RegularDeltaSIMD {
 
 struct NoDelta {
     ALWAYS_INLINE
-    static inline __m128i PrefixSum(__m128i curr, __m128i) {
+    static __m128i PrefixSum(__m128i curr, __m128i) {
         return curr;
     }
     ALWAYS_INLINE
-    static inline __m128i Delta(__m128i curr, __m128i) {
+    static __m128i Delta(__m128i curr, __m128i) {
         return curr;
     }
 
@@ -60,11 +60,11 @@ struct NoDelta {
 struct CoarseDelta4SIMD {
     ALWAYS_INLINE
     // Proposed and implemented by L. Boytosv
-    static inline __m128i PrefixSum(__m128i curr, __m128i prev) {
+    static __m128i PrefixSum(__m128i curr, __m128i prev) {
         return _mm_add_epi32(curr, prev);
     }
     ALWAYS_INLINE
-    static inline __m128i Delta(__m128i curr, __m128i prev) {
+    static __m128i Delta(__m128i curr, __m128i prev) {
         return _mm_sub_epi32(curr, prev);
     }
 
@@ -76,12 +76,12 @@ struct CoarseDelta4SIMD {
 struct CoarseDelta2SIMD {
     ALWAYS_INLINE
     // Proposed and implemented by L. Boytosv
-    static inline __m128i PrefixSum(__m128i curr, __m128i prev) {
+    static __m128i PrefixSum(__m128i curr, __m128i prev) {
         const __m128i _tmp1 = _mm_add_epi32(_mm_slli_si128(curr, 8), curr);
         return _mm_add_epi32(_tmp1, _mm_shuffle_epi32(prev, _MM_SHUFFLE(3, 2, 3, 2)));
     }
     ALWAYS_INLINE
-    static inline __m128i Delta(__m128i curr, __m128i prev) {
+    static __m128i Delta(__m128i curr, __m128i prev) {
         return _mm_sub_epi32(curr, _mm_or_si128(_mm_slli_si128(curr, 8), _mm_srli_si128(prev, 8)));
     }
     static bool usesDifferentialEncoding() { return true; }
@@ -92,11 +92,11 @@ struct CoarseDelta2SIMD {
 struct Max4DeltaSIMD {
     ALWAYS_INLINE
     // The idea is due to N. Kurz
-    static inline __m128i PrefixSum(__m128i curr, __m128i prev) {
+    static __m128i PrefixSum(__m128i curr, __m128i prev) {
         return _mm_add_epi32(curr, _mm_shuffle_epi32(prev, 0xff));
     }
     ALWAYS_INLINE
-    static inline __m128i Delta(__m128i curr, __m128i prev) {
+    static __m128i Delta(__m128i curr, __m128i prev) {
         return _mm_sub_epi32(curr,  _mm_shuffle_epi32(prev, 0xff));
     }
     static std::string name() { return "DeltaM4"; }

--- a/include/forcodec.h
+++ b/include/forcodec.h
@@ -38,19 +38,20 @@ class ForCODEC : public IntegerCODEC {
   public:
     void encodeArray(uint32_t *in, const size_t length, uint32_t *out,
                         size_t &nvalue) {
-      *(uint32_t *)out = length;
+      uint32_t cappedLength = static_cast<uint32_t>(std::min<size_t>(length, std::numeric_limits<uint32_t>::max()));
+      *(uint32_t *)out = cappedLength;
       out++;
       // for_compress_sorted() would be a bit faster, but requires
       // sorted input
       nvalue = (4 + for_compress_unsorted((const uint32_t *)in, (uint8_t *)out,
-                        length) + 3) / 4;
+                        cappedLength) + 3) / 4;
     }
 
     const uint32_t *decodeArray(const uint32_t *in, const size_t,
                         uint32_t *out, size_t &nvalue) {
       nvalue = *in;
       in++;
-      return in + for_uncompress((const uint8_t *)in, out, nvalue);
+      return in + for_uncompress((const uint8_t *)in, out, static_cast<uint32_t>(nvalue));
     }
 
     // append a key.
@@ -78,7 +79,7 @@ class ForCODEC : public IntegerCODEC {
 
     uint32_t select(const uint32_t *in, size_t index) {
       in++; // Skip length
-      return for_select((const uint8_t *)in, index);
+      return for_select((const uint8_t *)in, static_cast<uint32_t>(index));
     }
 
     string name() const {

--- a/include/frameofreference.h
+++ b/include/frameofreference.h
@@ -3,9 +3,6 @@
 #ifndef INCLUDE_FRAMEOFREFERENCE_H_
 #define INCLUDE_FRAMEOFREFERENCE_H_
 
-
-
-
 #include "common.h"
 #include "codecs.h"
 #include "util.h"
@@ -28,10 +25,9 @@ public:
 
     void encodeArray(uint32_t *in, const size_t length, uint32_t *out,
                      size_t &nvalue) {
-    	*out = length;
-        uint32_t * finalout =  compress_length(in,length, out  + 1);
+        *out = static_cast<uint32_t>(std::min<size_t>(length, std::numeric_limits<uint32_t>::max()));
+        uint32_t * finalout =  compress_length(in, *out, out  + 1);
         nvalue = finalout - out;
-
     }
 
     const uint32_t * uncompress_length(const uint32_t * in, uint32_t * out, uint32_t  nvalue);
@@ -41,7 +37,7 @@ public:
                                 uint32_t *out, size_t &nvalue) {
     	nvalue = *in;
     	in++;
-    	return uncompress_length(in,out,nvalue);
+    	return uncompress_length(in,out, static_cast<uint32_t>(nvalue));
     }
 
     // appends the value "value" at the end of the compressed stream. Assumes that we have
@@ -91,8 +87,8 @@ public:
 
     void encodeArray(uint32_t *in, const size_t length, uint32_t *out,
                      size_t &nvalue) {
-    	*out = length;
-        uint32_t * finalout =  simd_compress_length(in,length, out  + 1);
+        *out = static_cast<uint32_t>(std::min<size_t>(length, std::numeric_limits<uint32_t>::max()));
+        uint32_t * finalout =  simd_compress_length(in, *out, out  + 1);
         nvalue = finalout - out;
 
     }
@@ -103,9 +99,9 @@ public:
 
     const uint32_t *decodeArray(const uint32_t *in, const size_t ,
                                 uint32_t *out, size_t &nvalue) {
-    	nvalue = *in;
-    	in++;
-    	return simd_uncompress_length(in,out,nvalue);
+        nvalue = *in;
+        in++;
+        return simd_uncompress_length(in, out, static_cast<uint32_t>(nvalue));
     }
 
     // appends the value "value" at the end of the compressed stream. Assumes that we have

--- a/include/platform.h
+++ b/include/platform.h
@@ -36,7 +36,11 @@ uint32_t __inline __builtin_ctz(uint32_t value)
 
 uint32_t __inline __builtin_ctzl(uint64_t value)
 {
+#ifdef _M_X64
     unsigned long trailing_zero = 0;
     return _BitScanForward64(&trailing_zero, value) == 0 ? 64 : trailing_zero;
+#else
+    return ((value & 0xFFFFFFFF) == 0) ? (__builtin_ctz(value >> 32) + 32) : __builtin_ctz(value & 0xFFFFFFFF);
+#endif
 }
 #endif

--- a/include/simdbinarypacking.h
+++ b/include/simdbinarypacking.h
@@ -295,7 +295,7 @@ public:
             for (uint32_t i = 0; i < HowManyMiniBlocks; ++i) {
             	if(runningindex + 128 > index) {
             		return simdselectd1(&init, (const __m128i *)in, Bs[i],
-            		                index - runningindex);
+            		                static_cast<int>(index - runningindex));
             	}
             	simdscand1(&init, (const __m128i *)in, Bs[i]);
             	runningindex += MiniBlockSize;
@@ -314,14 +314,14 @@ public:
             for (uint32_t i = 0; i < howmany; ++i) {
             	if(runningindex + 128 > index) {
             		return simdselectd1(&init, (const __m128i *)in, Bs[i],
-            		                index - runningindex);
+            		                static_cast<int>(index - runningindex));
             	}
             	simdscand1(&init, (const __m128i *)in, Bs[i]);
             	runningindex += MiniBlockSize;
                 in += MiniBlockSize / 32 * Bs[i];
             }
         }
-        return runningindex;
+        return static_cast<uint32_t>(runningindex);
     }
 
 

--- a/include/simdbitpackinghelpers.h
+++ b/include/simdbitpackinghelpers.h
@@ -487,20 +487,20 @@ typedef void (*packingfunction)(const uint32_t *, __m128i *);
 constexpr unpackingfunction unpack[33] = {SIMD_nullunpacker32, __SIMD_fastunpack1, __SIMD_fastunpack2, __SIMD_fastunpack3, __SIMD_fastunpack4, __SIMD_fastunpack5, __SIMD_fastunpack6, __SIMD_fastunpack7, __SIMD_fastunpack8, __SIMD_fastunpack9, __SIMD_fastunpack10, __SIMD_fastunpack11, __SIMD_fastunpack12, __SIMD_fastunpack13, __SIMD_fastunpack14, __SIMD_fastunpack15, __SIMD_fastunpack16, __SIMD_fastunpack17, __SIMD_fastunpack18, __SIMD_fastunpack19, __SIMD_fastunpack20, __SIMD_fastunpack21, __SIMD_fastunpack22, __SIMD_fastunpack23, __SIMD_fastunpack24, __SIMD_fastunpack25, __SIMD_fastunpack26, __SIMD_fastunpack27, __SIMD_fastunpack28, __SIMD_fastunpack29, __SIMD_fastunpack30, __SIMD_fastunpack31, __SIMD_fastunpack32};
 
 ALWAYS_INLINE
-inline void SIMDunpack(const __m128i   *__restrict__ in, uint32_t   *__restrict__  out, const uint32_t bit) {
+void SIMDunpack(const __m128i   *__restrict__ in, uint32_t   *__restrict__  out, const uint32_t bit) {
     return unpack[bit](in, out);
 }
 
 constexpr packingfunction packwithoutmask[33] = {__SIMD_fastpackwithoutmask0, __SIMD_fastpackwithoutmask1, __SIMD_fastpackwithoutmask2, __SIMD_fastpackwithoutmask3, __SIMD_fastpackwithoutmask4, __SIMD_fastpackwithoutmask5, __SIMD_fastpackwithoutmask6, __SIMD_fastpackwithoutmask7, __SIMD_fastpackwithoutmask8, __SIMD_fastpackwithoutmask9, __SIMD_fastpackwithoutmask10, __SIMD_fastpackwithoutmask11, __SIMD_fastpackwithoutmask12, __SIMD_fastpackwithoutmask13, __SIMD_fastpackwithoutmask14, __SIMD_fastpackwithoutmask15, __SIMD_fastpackwithoutmask16, __SIMD_fastpackwithoutmask17, __SIMD_fastpackwithoutmask18, __SIMD_fastpackwithoutmask19, __SIMD_fastpackwithoutmask20, __SIMD_fastpackwithoutmask21, __SIMD_fastpackwithoutmask22, __SIMD_fastpackwithoutmask23, __SIMD_fastpackwithoutmask24, __SIMD_fastpackwithoutmask25, __SIMD_fastpackwithoutmask26, __SIMD_fastpackwithoutmask27, __SIMD_fastpackwithoutmask28, __SIMD_fastpackwithoutmask29, __SIMD_fastpackwithoutmask30, __SIMD_fastpackwithoutmask31, __SIMD_fastpackwithoutmask32};
 
 ALWAYS_INLINE
-inline void SIMDpackwithoutmask(const uint32_t   *__restrict__ in, __m128i   *__restrict__  out, const uint32_t bit) {
+void SIMDpackwithoutmask(const uint32_t   *__restrict__ in, __m128i   *__restrict__  out, const uint32_t bit) {
     packwithoutmask[bit](in, out);
 }
 constexpr packingfunction pack[33] = {__SIMD_fastpack0, __SIMD_fastpack1, __SIMD_fastpack2, __SIMD_fastpack3, __SIMD_fastpack4, __SIMD_fastpack5, __SIMD_fastpack6, __SIMD_fastpack7, __SIMD_fastpack8, __SIMD_fastpack9, __SIMD_fastpack10, __SIMD_fastpack11, __SIMD_fastpack12, __SIMD_fastpack13, __SIMD_fastpack14, __SIMD_fastpack15, __SIMD_fastpack16, __SIMD_fastpack17, __SIMD_fastpack18, __SIMD_fastpack19, __SIMD_fastpack20, __SIMD_fastpack21, __SIMD_fastpack22, __SIMD_fastpack23, __SIMD_fastpack24, __SIMD_fastpack25, __SIMD_fastpack26, __SIMD_fastpack27, __SIMD_fastpack28, __SIMD_fastpack29, __SIMD_fastpack30, __SIMD_fastpack31, __SIMD_fastpack32};
 
 ALWAYS_INLINE
-inline void SIMDpack(const uint32_t   *__restrict__ in, __m128i   *__restrict__  out, const uint32_t bit) {
+void SIMDpack(const uint32_t   *__restrict__ in, __m128i   *__restrict__  out, const uint32_t bit) {
     pack[bit](in, out);
 }
 
@@ -510,20 +510,20 @@ inline void SIMDpack(const uint32_t   *__restrict__ in, __m128i   *__restrict__ 
 constexpr unpackingfunction Uunpack[33] = {uSIMD_nullunpacker32, __uSIMD_fastunpack1, __uSIMD_fastunpack2, __uSIMD_fastunpack3, __uSIMD_fastunpack4, __uSIMD_fastunpack5, __uSIMD_fastunpack6, __uSIMD_fastunpack7, __uSIMD_fastunpack8, __uSIMD_fastunpack9, __uSIMD_fastunpack10, __uSIMD_fastunpack11, __uSIMD_fastunpack12, __uSIMD_fastunpack13, __uSIMD_fastunpack14, __uSIMD_fastunpack15, __uSIMD_fastunpack16, __uSIMD_fastunpack17, __uSIMD_fastunpack18, __uSIMD_fastunpack19, __uSIMD_fastunpack20, __uSIMD_fastunpack21, __uSIMD_fastunpack22, __uSIMD_fastunpack23, __uSIMD_fastunpack24, __uSIMD_fastunpack25, __uSIMD_fastunpack26, __uSIMD_fastunpack27, __uSIMD_fastunpack28, __uSIMD_fastunpack29, __uSIMD_fastunpack30, __uSIMD_fastunpack31, __uSIMD_fastunpack32};
 
 ALWAYS_INLINE
-inline void uSIMDunpack(const __m128i   *__restrict__ in, uint32_t   *__restrict__  out, const uint32_t bit) {
+void uSIMDunpack(const __m128i   *__restrict__ in, uint32_t   *__restrict__  out, const uint32_t bit) {
     return Uunpack[bit](in, out);
 }
 
 constexpr packingfunction Upackwithoutmask[33] = {__uSIMD_fastpackwithoutmask0, __uSIMD_fastpackwithoutmask1, __uSIMD_fastpackwithoutmask2, __uSIMD_fastpackwithoutmask3, __uSIMD_fastpackwithoutmask4, __uSIMD_fastpackwithoutmask5, __uSIMD_fastpackwithoutmask6, __uSIMD_fastpackwithoutmask7, __uSIMD_fastpackwithoutmask8, __uSIMD_fastpackwithoutmask9, __uSIMD_fastpackwithoutmask10, __uSIMD_fastpackwithoutmask11, __uSIMD_fastpackwithoutmask12, __uSIMD_fastpackwithoutmask13, __uSIMD_fastpackwithoutmask14, __uSIMD_fastpackwithoutmask15, __uSIMD_fastpackwithoutmask16, __uSIMD_fastpackwithoutmask17, __uSIMD_fastpackwithoutmask18, __uSIMD_fastpackwithoutmask19, __uSIMD_fastpackwithoutmask20, __uSIMD_fastpackwithoutmask21, __uSIMD_fastpackwithoutmask22, __uSIMD_fastpackwithoutmask23, __uSIMD_fastpackwithoutmask24, __uSIMD_fastpackwithoutmask25, __uSIMD_fastpackwithoutmask26, __uSIMD_fastpackwithoutmask27, __uSIMD_fastpackwithoutmask28, __uSIMD_fastpackwithoutmask29, __uSIMD_fastpackwithoutmask30, __uSIMD_fastpackwithoutmask31, __uSIMD_fastpackwithoutmask32};
 
 ALWAYS_INLINE
-inline void uSIMDpackwithoutmask(const uint32_t   *__restrict__ in, __m128i   *__restrict__  out, const uint32_t bit) {
+void uSIMDpackwithoutmask(const uint32_t   *__restrict__ in, __m128i   *__restrict__  out, const uint32_t bit) {
     Upackwithoutmask[bit](in, out);
 }
 constexpr packingfunction Upack[33] = {__uSIMD_fastpack0, __uSIMD_fastpack1, __uSIMD_fastpack2, __uSIMD_fastpack3, __uSIMD_fastpack4, __uSIMD_fastpack5, __uSIMD_fastpack6, __uSIMD_fastpack7, __uSIMD_fastpack8, __uSIMD_fastpack9, __uSIMD_fastpack10, __uSIMD_fastpack11, __uSIMD_fastpack12, __uSIMD_fastpack13, __uSIMD_fastpack14, __uSIMD_fastpack15, __uSIMD_fastpack16, __uSIMD_fastpack17, __uSIMD_fastpack18, __uSIMD_fastpack19, __uSIMD_fastpack20, __uSIMD_fastpack21, __uSIMD_fastpack22, __uSIMD_fastpack23, __uSIMD_fastpack24, __uSIMD_fastpack25, __uSIMD_fastpack26, __uSIMD_fastpack27, __uSIMD_fastpack28, __uSIMD_fastpack29, __uSIMD_fastpack30, __uSIMD_fastpack31, __uSIMD_fastpack32};
 
 ALWAYS_INLINE
-inline void uSIMDpack(const uint32_t   *__restrict__ in, __m128i   *__restrict__  out, const uint32_t bit) {
+void uSIMDpack(const uint32_t   *__restrict__ in, __m128i   *__restrict__  out, const uint32_t bit) {
     Upack[bit](in, out);
 }
 

--- a/include/streamvariablebyte.h
+++ b/include/streamvariablebyte.h
@@ -41,7 +41,7 @@ public:
     void encodeArray(uint32_t *in, const size_t count, uint32_t *out,
                      size_t &nvalue) {
         uint64_t bytesWritten = svb_encode((uint8_t *)out, in, static_cast<uint32_t>(std::min<size_t>(count, std::numeric_limits<uint32_t>::max())), 0, 1);
-        nvalue = (bytesWritten + 3)/4;
+        nvalue = static_cast<size_t>(bytesWritten + 3)/4;
     }
 
     const uint32_t * decodeArray(const uint32_t *in, const size_t /* count */,

--- a/include/streamvariablebyte.h
+++ b/include/streamvariablebyte.h
@@ -40,7 +40,7 @@ class StreamVByte : public IntegerCODEC {
 public:
     void encodeArray(uint32_t *in, const size_t count, uint32_t *out,
                      size_t &nvalue) {
-        uint64_t bytesWritten = svb_encode((uint8_t *)out, in, count, 0, 1);
+        uint64_t bytesWritten = svb_encode((uint8_t *)out, in, static_cast<uint32_t>(std::min<size_t>(count, std::numeric_limits<uint32_t>::max())), 0, 1);
         nvalue = (bytesWritten + 3)/4;
     }
 
@@ -74,16 +74,16 @@ public:
 
     void encodeArray(uint32_t *in, const size_t count, uint32_t *out,
                      size_t &nvalue) {
-        uint32_t bytesWritten = svb_encode((uint8_t *)(out + 1), in,
-                                    count, 1, 1);
+        uint32_t bytesWritten = static_cast<uint32_t>(svb_encode((uint8_t *)(out + 1), in,
+                                    static_cast<uint32_t>(std::min<size_t>(count, std::numeric_limits<uint32_t>::max())), 1, 1));
         *out = 4 + bytesWritten;
         nvalue = 1 + (bytesWritten + 3) / 4;
     }
 
     void encodeToByteArray(uint32_t *in, const size_t count, uint8_t *out,
                      size_t &nvalue) {
-        uint32_t bytesWritten = svb_encode((uint8_t *)(out + 1), in,
-                                    count, 1, 1);
+        uint32_t bytesWritten = static_cast<uint32_t>(svb_encode((uint8_t *)(out + 1), in,
+                                    static_cast<uint32_t>(std::min<size_t>(count, std::numeric_limits<uint32_t>::max())), 1, 1));
         *out = 4 + bytesWritten;
         nvalue = 4 + bytesWritten;
     }
@@ -154,16 +154,16 @@ public:
             size = 8;
 
         uint8_t *keyPtr = (uint8_t *)in;       // full list of keys is next
-        uint32_t keyLen = ((count + 3) / 4);   // 2-bits per key (rounded up)
+        uint32_t keyLen = static_cast<uint32_t>((count + 3) / 4);   // 2-bits per key (rounded up)
         uint8_t *dataPtr = keyPtr + keyLen;    // data starts after the keys
         size = svb_append_scalar_d1(keyPtr, dataPtr, size - 8, count,
                             key - previous_key) - initin;
 
         // update 'size' and 'count' at the beginning of the buffer
         in = initin;
-        *(uint32_t *)in = size;
+        *(uint32_t *)in = static_cast<uint32_t>(size);
         in += 4;
-        *(uint32_t *)in = count + 1;
+        *(uint32_t *)in = static_cast<uint32_t>(count + 1);
         return size;
     }
 
@@ -190,9 +190,9 @@ public:
         *(in + 1) = count + 1;
 
         uint32_t position;
-        uint32_t bytesWritten = svb_insert_scalar_d1_init(keyPtr, dataPtr,
+        uint32_t bytesWritten = static_cast<uint32_t>(svb_insert_scalar_d1_init(keyPtr, dataPtr,
                                     dataSize, count, 0, key, &position)
-                                - (uint8_t *)in;
+                                - (uint8_t *)in);
         *in = bytesWritten; 
         return (bytesWritten + 3) / 4;
     }
@@ -221,9 +221,9 @@ public:
         *(in + 1) = count + 1;
 
         uint32_t position;
-        uint32_t bytesWritten = svb_insert_scalar_d1_init(keyPtr, dataPtr,
+        uint32_t bytesWritten = static_cast<uint32_t>(svb_insert_scalar_d1_init(keyPtr, dataPtr,
                                     dataSize, count, 0, key, &position)
-                                - (uint8_t *)in;
+                                - (uint8_t *)in);
         *in = bytesWritten;
         return bytesWritten;
     }

--- a/include/util.h
+++ b/include/util.h
@@ -79,7 +79,7 @@ uint32_t maxbits(const iterator &begin, const iterator &end) {
 template <class T>
 CONST_FUNCTION
 inline bool needPaddingTo128Bits(const T *inbyte) {
-    return reinterpret_cast<uintptr_t>(inbyte) & 15;
+    return (reinterpret_cast<uintptr_t>(inbyte) & 15) != 0;
 }
 
 
@@ -88,7 +88,7 @@ inline bool needPaddingTo128Bits(const T *inbyte) {
 template <class T>
 CONST_FUNCTION
 inline bool needPaddingTo32Bits(const T *inbyte) {
-    return reinterpret_cast<uintptr_t>(inbyte) & 3;
+    return (reinterpret_cast<uintptr_t>(inbyte) & 3) != 0;
 }
 
 template <class T>

--- a/include/util.h
+++ b/include/util.h
@@ -47,10 +47,6 @@ inline uint32_t maxbitas32int(const __m128i accumulator) {
     return gccbits(tmparray[0] | tmparray[1] | tmparray[2] | tmparray[3]);
 }
 
-// for clarity
-#define min(X, Y)  ((X) < (Y) ? (X) : (Y))
-
-
 static CONST_FUNCTION
 bool divisibleby(size_t a, uint32_t x) {
     return (a % x == 0);

--- a/include/varintgb.h
+++ b/include/varintgb.h
@@ -247,7 +247,7 @@ public:
 			uint8_t * fb = encodeGroupVarIntDelta(block1->data, initial,
 					tmpbuffer);
 
-			block1->length = fb - block1->data;
+			block1->length = static_cast<uint32_t>(fb - block1->data);
 			uint32_t nextval = tmpbuffer[4] - tmpbuffer[3];
 			uint32_t newsel = getByteLength(nextval) - 1;
 			// everything after that is just going to be shifting
@@ -372,7 +372,7 @@ public:
 			i += 4;
 		}
 		if (endbyte > inbyte && nvalue > i) {
-			uint32_t tnvalue = nvalue - 1 - i;
+			uint32_t tnvalue = static_cast<uint32_t>(nvalue - 1 - i);
 			inbyte = decodeCarefully(inbyte, &initial, out, tnvalue);
 			assert(inbyte <= endbyte);
 			if (key <= out[0]) {
@@ -434,7 +434,7 @@ public:
                 return (out[index - (i - 4)]);
         }
         {
-        	nvalue = nvalue - i;
+            nvalue = static_cast<uint32_t>(nvalue - i);
             inbyte = decodeCarefully(inbyte, &initial, out, nvalue);
             if (index == i)
                 return (out[0]);
@@ -632,9 +632,9 @@ private:
 
 
     void sortinfirstvalue(uint32_t * tmpbuffer, size_t length) {
-    	int top = length < 4 ? length : 4;
+    	size_t top = length < 4 ? length : 4;
 
-    	for (int j = 0; j < top; ++j) {
+    	for (size_t j = 0; j < top; ++j) {
     		if (tmpbuffer[j] > tmpbuffer[j + 1]) {
     			uint32_t t = tmpbuffer[j + 1];
     			tmpbuffer[j + 1] = tmpbuffer[j];
@@ -882,9 +882,9 @@ private:
 		return readinginbyte+b->length;
 	}
 
-	const uint8_t * loadblockcarefully(Block * b, const uint8_t * readinginbyte, int howmanyvals) {
+	const uint8_t * loadblockcarefully(Block * b, const uint8_t * readinginbyte, size_t howmanyvals) {
 		b->length = 1;
-		for(int k = 0; k < howmanyvals; ++k)
+		for(size_t k = 0; k < howmanyvals; ++k)
 			b->length += 1 + ((readinginbyte[0]>>(2*k)) & 3);
 		memcpy(b->data,readinginbyte,b->length);
 		return readinginbyte+b->length;
@@ -905,11 +905,11 @@ private:
 		*newsel = newnextsel;
 	}
 
-	void finalshiftin(Block * b, uint32_t nextval, uint32_t newsel, int howmany) {
+	void finalshiftin(Block * b, uint32_t nextval, uint32_t newsel, size_t howmany) {
 		b->data[0] = (b->data[0]<<2) | newsel;
 		std::memmove(b->data + 2 + newsel,b->data + 1,b->length - 1 );
 		b->length = 1;
-		for(int k = 0; k < howmany; ++k)
+		for(size_t k = 0; k < howmany; ++k)
 			b->length += 1 + ((b->data[0]>>(2*k)) & 3);
 		std::memcpy(b->data + 1, &nextval,newsel + 1);
 	}

--- a/msvc/SIMDCompressionAndIntersection.vcxproj
+++ b/msvc/SIMDCompressionAndIntersection.vcxproj
@@ -71,9 +71,13 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>simdcomp_a</TargetName>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>simdcomp_a</TargetName>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>simdcomp_a</TargetName>

--- a/src/for.c
+++ b/src/for.c
@@ -225,7 +225,7 @@ for_uncompress_bits(const uint8_t *in, uint32_t *out, uint32_t length,
   for (; i + 8 <= length; i += 8, out += 8)
     in += for_unpack8[bits](base, in, out);
 
-  return (in - bin) + for_unpackx[bits](base, in, out, length - i);
+  return (uint32_t)(in - bin) + for_unpackx[bits](base, in, out, length - i);
 }
 
 uint32_t
@@ -306,7 +306,7 @@ for_append_bits(uint8_t *in, uint32_t length, uint32_t base,
     *(in32 + 1) |= value >> (32 - start);
   }
 
-  return (in - initin) + ((start + bits) + 7) / 8;
+  return (uint32_t)(in - initin) + ((start + bits) + 7) / 8;
 }
 
 typedef uint32_t (* append_impl)(const uint32_t *in, uint8_t *out,

--- a/src/frameofreference.cpp
+++ b/src/frameofreference.cpp
@@ -7653,7 +7653,7 @@ static uint32_t fastselect(selectmetadata * s, size_t index) {
         uint32_t packedsizeinwords = packedlength * s->b / 32;
         return s->in[packedsizeinwords +  index - packedlength];
     }
-    const int bitoffset = index * s->b; /* how many bits  */
+    const int bitoffset = static_cast<uint32_t>(index) * s->b; /* how many bits  */
     const int firstword = bitoffset / 32;
     const int secondword = (bitoffset + s->b - 1) / 32;
     const uint32_t firstpart = s->in[firstword]
@@ -12037,7 +12037,7 @@ uint32_t SIMDCompressionLib::FrameOfReference::select(const uint32_t *in, size_t
         uint32_t packedsizeinwords = packedlength * b / 32;
         return in[packedsizeinwords +  index - packedlength];
     }
-    const int bitoffset = index * b; /* how many bits  */
+    const int bitoffset = static_cast<uint32_t>(index) * b; /* how many bits  */
     const int firstword = bitoffset / 32;
     const int secondword = (bitoffset + b - 1) / 32;
     const uint32_t firstpart = in[firstword]
@@ -27031,7 +27031,7 @@ static uint32_t simdfastselect(const uint32_t * in, int b, uint32_t m, size_t in
     //	return in[index];
     //}
     const int lane = index % 4; /* we have 4 interleaved lanes */
-    const int bitsinlane = (index / 4) * b; /* how many bits in lane */
+    const int bitsinlane = static_cast<uint32_t>(index / 4) * b; /* how many bits in lane */
     const int firstwordinlane = bitsinlane / 32;
     const int secondwordinlane = (bitsinlane + b - 1) / 32;
     const uint32_t firstpart = in[4 * firstwordinlane + lane]
@@ -27207,11 +27207,11 @@ size_t SIMDCompressionLib::SIMDFrameOfReference::append(uint8_t *inbyte, const s
 	size_t oldhowmanyfull = nvalue / 128;
 	uint32_t * const newin = in +  4 * b * oldhowmanyfull;
 	size_t need_decoding = nvalue - oldhowmanyfull * 128;
-	simdunpackFOR_length(m, (__m128i *)newin, need_decoding, buffer, b);
+	simdunpackFOR_length(m, (__m128i *)newin, static_cast<int>(need_decoding), buffer, b);
 
 	buffer[need_decoding] = value;
 
-	uint32_t * out = (uint32_t *)simdpackFOR_length(m, buffer, need_decoding + 1 , (__m128i *) newin,b);
+	uint32_t * out = (uint32_t *)simdpackFOR_length(m, buffer, static_cast<int>(need_decoding + 1), (__m128i *) newin,b);
 
     return ( out - in + headersize )  * sizeof(uint32_t);
 }

--- a/src/streamvbyte.c
+++ b/src/streamvbyte.c
@@ -149,7 +149,7 @@ static inline uint32_t _decode_data(uint8_t **dataPtrPtr, uint8_t code) {
 uint8_t *svb_append_scalar_d1(uint8_t *keyPtr, uint8_t *dataPtr,
                             size_t sizebytes, size_t count, uint32_t delta)
 {
-    uint32_t keyLen = (count + 3) / 4; // 2-bits rounded to full byte
+    uint32_t keyLen = (uint32_t)(count + 3) / 4; // 2-bits rounded to full byte
 
     // make space for additional keys?
     if (count >= keyLen * 4) {
@@ -1220,7 +1220,7 @@ int svb_find_avx_d1_init(uint8_t *keyPtr,
 
     // key was not found!
     *presult = key + 1;
-    return (count);
+    return (int) count;
 }
 
 int svb_find_scalar_d1_init(uint8_t *keyPtr,
@@ -1244,7 +1244,7 @@ int svb_find_scalar_d1_init(uint8_t *keyPtr,
     }
 
     *presult = searchkey + 1;
-    return count;
+    return (int) count;
 }
 
 

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -283,8 +283,8 @@ void testFindSimple() {
 
     uint32_t k = 0;
     for (int i = 0; i < max; i++) {
-        int pos = codec.findLowerBound(compressedbuffer.data(), max, i, &k);
-        if (k != (uint32_t)i && pos != i) {
+        size_t pos = codec.findLowerBound(compressedbuffer.data(), max, i, &k);
+        if (k != (uint32_t)i && pos != static_cast<size_t>(i)) {
             cout << codec.name() << "::findLowerBoundDelta failed with "
                  << i << endl;
             throw std::logic_error("bug");
@@ -302,7 +302,7 @@ void testFindAdvanced() {
     // print random seed to make the test reproducable
     time_t t = ::time(0);
     cout << "Seed is " << t << endl;
-    ::srand(t);
+    ::srand(static_cast<unsigned int>(t));
 
     // initialize
     for (int i = 0; i < max; i++)
@@ -315,10 +315,10 @@ void testFindAdvanced() {
 
     uint32_t k1 = 0;
     uint32_t k2 = 0;
-    for (int i = 0; i < max * 2; i++) {
-        int pos1 = codec.findLowerBound(compressedbuffer.data(), max, i, &k1);
+    for (uint32_t i = 0; i < max * 2; i++) {
+        size_t pos1 = codec.findLowerBound(compressedbuffer.data(), max, i, &k1);
         uint32_t *it = std::lower_bound(&ints[0], &ints[max], i);
-        int pos2 = it - &ints[0];
+        size_t pos2 = static_cast<size_t>(it - &ints[0]);
         k2 = *it;
         // key not found?
         if (it == &ints[max] && pos1 != max) {
@@ -359,7 +359,7 @@ void testInsert() {
 
 	size_t currentsize = 0;
 	for (int i = 0; i < max; i++) {
-		currentsize = codec.insert(compressedbuffer.data(), currentsize, ints[i]);
+		currentsize = codec.insert(compressedbuffer.data(), static_cast<uint32_t>(currentsize), ints[i]);
 		size_t howmany = decomp.size();
 		codec.decodeArray(compressedbuffer.data(),currentsize,decomp.data(),howmany);
 		sofar.push_back(ints[i]);
@@ -550,7 +550,7 @@ void testSelectAdvanced() {
     // print random seed to make the test reproducable
     time_t t = ::time(0);
     cout << "Seed is " << t << endl;
-    ::srand(t);
+    ::srand(static_cast<unsigned int>(t));
 
     // fill array with "random" values
     for (int i = 0; i < max; i++)


### PR DESCRIPTION
This PR fixes all the warnings issued by Visual C++ 2015 (issued at Warning Level 3, the default) when compiling the latest code. The difference can be seen in these two builds: before (https://ci.appveyor.com/project/BradleyGrainger/simdcompressionandintersection/build/1.0.2) and after (https://ci.appveyor.com/project/BradleyGrainger/simdcompressionandintersection/build/1.0.4).

All unit tests pass on Mac OS X 10.10 and Windows 10.