### PR TITLE
use quote instead of bracket include

### DIFF
--- a/include/intersection.h
+++ b/include/intersection.h
@@ -3,7 +3,7 @@
 #ifndef SIMDCompressionAndIntersection_INTERSECTION_H_
 #define SIMDCompressionAndIntersection_INTERSECTION_H_
 
-#include <common.h>
+#include "common.h"
 
 namespace SIMDCompressionLib {
 


### PR DESCRIPTION
Using #include "common.h" allows users to namespace the include files to avoid clashes (e.g. #include "simdcomp/include/intersection.h")
It's only missing in one place.