### PR TITLE
fix buggy use of 32 bit ctzl that resulted in crashes with recent MSVC

### DIFF
--- a/include/boolarray.h
+++ b/include/boolarray.h
@@ -16,7 +16,7 @@ using namespace std;
 static inline int numberOfTrailingZeros(uint64_t x) {
   if (x == 0)
     return 64;
-  return __builtin_ctzl(x);
+  return __builtin_ctzll(x);
 }
 
 class BoolArray {
@@ -90,7 +90,7 @@ public:
     for (uint32_t k = 0; k < buffer.size(); ++k) {
       uint64_t myword = buffer[k];
       while (myword != 0) {
-        int ntz = __builtin_ctzl(myword);
+        int ntz = __builtin_ctzll(myword);
         ans[pos++] = k * 64 + ntz;
         myword ^= (1ll << ntz);
       }

--- a/include/platform.h
+++ b/include/platform.h
@@ -22,17 +22,19 @@
 #ifdef _MSC_VER
 #include <intrin.h>
 
-uint32_t __inline __builtin_clz(uint32_t value) {
+int __inline __builtin_clz(uint32_t value) {
   unsigned long leading_zero = 0;
   return _BitScanReverse(&leading_zero, value) == 0 ? 0 : (31 - leading_zero);
 }
 
-uint32_t __inline __builtin_ctz(uint32_t value) {
+int __inline __builtin_ctz(uint32_t value) {
   unsigned long trailing_zero = 0;
   return _BitScanForward(&trailing_zero, value) == 0 ? 32 : trailing_zero;
 }
 
-uint32_t __inline __builtin_ctzl(uint64_t value) {
+// NOTE: avoid ctzl / clzl since long is 32 bits for MSVC
+
+int __inline __builtin_ctzll(uint64_t value) {
 #ifdef _M_X64
   unsigned long trailing_zero = 0;
   return _BitScanForward64(&trailing_zero, value) == 0 ? 64 : trailing_zero;

--- a/include/synthetic.h
+++ b/include/synthetic.h
@@ -218,7 +218,7 @@ public:
 
   double zeta(int nn, double ttheta) {
     double sum = 0;
-    for (long i = 0; i < nn; i++) {
+    for (int i = 0; i < nn; i++) {
       sum += 1 / (pow(i + 1, ttheta));
     }
     return sum;

--- a/makefile.vc
+++ b/makefile.vc
@@ -18,11 +18,11 @@ LINK=link.exe
 INC = /Iinclude
 
 !IF "$(DEBUG)"=="yes"
-CFLAGS = /nologo /MDd /LDd /Od /Zi /D_DEBUG /D__SSSE3__ /RTC1 /W3 /wd"4141" /GS /Gm /arch:AVX
+CFLAGS = /nologo /MDd /LDd /Od /Zi /D_DEBUG /D__SSSE3__ /RTC1 /W3 /wd"4141" /GS /Gm /arch:AVX /EHsc
 ARFLAGS = /nologo
 LDFLAGS = /nologo /debug /nodefaultlib:msvcrt
 !ELSE
-CFLAGS = /nologo /MD /O2 /Zi /DNDEBUG /D__SSSE3__ /W3 /wd"4141" /Gm- /GS /Gy /Oi /GL /MP /arch:AVX
+CFLAGS = /nologo /MD /O2 /Zi /DNDEBUG /D__SSSE3__ /W3 /wd"4141" /Gm- /GS /Gy /Oi /GL /MP /arch:AVX /EHsc
 ARFLAGS = /nologo /LTCG
 LDFLAGS = /nologo /LTCG /DYNAMICBASE /incremental:no /debug /opt:ref,icf
 !ENDIF
@@ -41,6 +41,10 @@ lib: $(LIB_OBJS)
 unit: lib
 	$(CC) $(INC) $(CFLAGS) /c src/unit.cpp
 	$(LINK) $(LDFLAGS) /OUT:unit.exe unit.obj simdcomp_a.lib
+
+example: lib
+	$(CC) $(INC) $(CFLAGS) /c example.cpp
+	$(LINK) $(LDFLAGS) /OUT:example.exe example.obj simdcomp_a.lib
 
 clean:
 	del /Q *.obj


### PR DESCRIPTION
This patch fixes failing unit tests as well as cleans up a few other MSVC/Windows things.

Out of the box, with a recent MSVC (v19.27.29112), the unit tests segfault at this point:

> testing issue 18 ... with codec VByteDelta... ok!
> 0
> 

There was also an interesting compiler warning:

> predefined C++ types (compiler internal)(344): warning C4244: 'argument': conversion from '_T' to 'unsigned long', possible loss of data
>         with
>         [
>             _T=uint64_t
>         ]
> e:\opt\code\simd_orig\include\boolarray.h(20): note: see reference to function template instantiation 'int __ctz_helper<uint64_t>(_T)' being compiled
>         with
>         [
>             _T=uint64_t
>         ]
>         link.exe /nologo /LTCG /DYNAMICBASE /incremental:no /debug /opt:ref,icf /OUT:unit.exe unit.obj simdcomp_a.lib
> 

And also:

> error C2556: 'uint32_t __builtin_clz(uint32_t)': overloaded function differs only by return type from 'int __builtin_clz(unsigned int) 

So it *looks* like recent MSVC has some internal/magic support for __builtin_ctz and friends.  But when I commented out the definitions in platform.h, I got 

> src/simdpackedsearch.c(104): warning C4013: '__builtin_ctz' undefined; assuming extern returning int

And it's not defined in any microsoft headers that I can find.

Anyway, I tracked down the crashes to the use of __builtin_ctzl, which this recent magic support in MSVC gets precedence, and instead of calling the 64 bit version in platform.h, calls the internal one.  And it looks like the internal MSVC one has a signature literally the same as in GCC/clang "int __builtin_ctzl (unsigned long)", which would have been very helpful... except that "long" in MSVC is only 32 bits, even in 64 bit mode!

For maximum back compatibility, the fix I pursued was to simply change to using __builtin_ctzll, which takes "long long" which is 64 bits in all of these compilers.  The unit tests now pass fine.

To get rid of other compiler warnings, I fixed the return types of __builtin_clz to be "int" to match both gcc and the recent MSVC version.  I fixed the one spurious use of "long" in the codebase that was not related to matching the signature of ctz.  I also added /EHsc for stack unwinding since throw is used, and added a target for "example" in the makefile.
